### PR TITLE
trigger event each time a shape is clicked

### DIFF
--- a/src/diagram/diagram-public-types.ts
+++ b/src/diagram/diagram-public-types.ts
@@ -31,7 +31,7 @@ interface IDiagramConnector extends IDiagramElement {
 
 // event
 
-type DiagramEventType = 'select' | 'connect' | 'disconnect';
+type DiagramEventType = 'select' | 'connect' | 'disconnect' | 'onclick';
 
 interface IDiagramEventSelectDetail<T extends IDiagramShape & IDiagramConnector> {
 	target: T;

--- a/src/diagram/diagram.js
+++ b/src/diagram/diagram.js
@@ -79,6 +79,7 @@ export class Diagram extends EventTarget {
 				}
 				break;
 			case 'pointerdown':
+				this._dispatchEvent('onclick', { target: evt.detail.target })
 				switch (evt.detail.target.type) {
 					case 'canvas':
 					case 'shape':


### PR DESCRIPTION
I have a read only mode where when user click on a shape it should trigger an action. So the `select` event is not enough.
I suggest we add this event too.